### PR TITLE
Add missing layer to tilestats file

### DIFF
--- a/tilestats.json
+++ b/tilestats.json
@@ -1,6 +1,6 @@
 {
     "tilestats": {
-        "layerCount": 22,
+        "layerCount": 26,
         "layers": [
             {
                 "layer": "place_labels",
@@ -47,6 +47,18 @@
                 "geometry": "Polygon"
             },
             {
+                "layer": "street_polygons",
+                "geometry": "Polygon"
+            },
+            {
+                "layer": "streets_polygons_labels",
+                "geometry": "Point"
+            },
+            {
+                "layer": "ferries",
+                "geometry": "LineString"
+            },
+            {
                 "layer": "streets",
                 "geometry": "LineString"
             },
@@ -89,6 +101,10 @@
             {
                 "layer": "sites",
                 "geometry": "Polygon"
+            },
+            {
+                "layer": "pois",
+                "geometry": "Point"
             }
         ]
     }


### PR DESCRIPTION
This information is needed if you want to use vector tiles with GDAL. Tilemaker does not write this information into the metadata.json file. One can use tilestats.json to patch the metadata.json file generated by Tilemaker. Otherwise GDAL reads all tiles on the requested zoom level to find out the geometry type of each layer.

This pull request adds recently added layers.