### PR TITLE
Export all rivers and riverbanks as river as described in the docs

### DIFF
--- a/process.lua
+++ b/process.lua
@@ -396,8 +396,8 @@ function process_water_polygons(way, way_area)
 	elseif is_river or waterway == "dock" or waterway == "canal" then
 		mz = math.max(4, zmin_for_area(way, 0.1, way_area))
 		kind = waterway
-		if kind == "" then
-			kind = water
+                if is_river then
+			kind = "river"
 		end
 	end
 	if mz < inf_zoom then


### PR DESCRIPTION
Currently rivers are written as either `kind=river` or `kind=riverbank` to the vector tiles depending on their tagging. However, the documentation contains `river` only.